### PR TITLE
opt(account): stop copies of `Account` on methods

### DIFF
--- a/account.go
+++ b/account.go
@@ -38,7 +38,7 @@ func CreateAccount(signingKeyHex string) (Account, error) {
 	}
 }
 
-func (account Account) CreateSignature(message string) (string, error) {
+func (account *Account) CreateSignature(message string) (string, error) {
 	signatureByte, err := account.SigningKey.Sign(nil, []byte(message), crypto.Hash(0))
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Currently, every time you call `Account.CreateSignature`, it will copy the entire `Account` data along with the crypto struct fields (recursively) and send that clone into the `CreateSignature` method.  Now, it will take a pointer to the data (reference like JS objects) instead of straight-up copying everything.